### PR TITLE
fix: add missing comma to JSON

### DIFF
--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -169,7 +169,7 @@ jobs:
           payload: |
             {
               "kontrol_status": "Failure",
-              "ci_run_link": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "ci_run_link": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "blocks": [
                 {
                   "type": "section",


### PR DESCRIPTION
This fixes:

```
Run slackapi/slack-github-action@v1.26.0
passed in payload was invalid JSON
Error: Error: Need to provide valid JSON payload
```

which you can find here: https://github.com/runtimeverification/optimism-ci/actions/runs/10426642306/job/28879961326