### PR TITLE
chore: don't notify on cancelled

### DIFF
--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -163,7 +163,7 @@ jobs:
               }'
         
       - name: Send Status Failure to Slack
-        if: always() && (failure() || cancelled())
+        if: always() && failure()
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |


### PR DESCRIPTION
CI runs are often canceled, for example when two PRs are quickly merged to develop. In this case we get a failure notification of:

> Canceling since a higher priority waiting request for 'Client: Optimism-refs/heads/master-develop' exists 

This PR avoids sending notifications on cancellation and only sends them when the job actually fails