### PR TITLE
Add OP retro funding verification

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+  “opRetro”: {
+    “projectId”: “0x80393c05d524b7a6f7a78b0c141eadf0759642ae8d7e718134318cd2d73d5464”
+  }
+}


### PR DESCRIPTION
This PR adds `funding.json` for the OP Retro grant application:
```
{
  “opRetro”: {
    “projectId”: “0x80393c05d524b7a6f7a78b0c141eadf0759642ae8d7e718134318cd2d73d5464”
  }
}
```