### PR TITLE
Update optimism-ci.yaml

### DIFF
--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -77,7 +77,8 @@ jobs:
       - name: "Set up Rust Toolchain"
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: "extractions/setup-just@v1"
+      - name: "Install Just"
+        uses: extractions/setup-just@v1
         with:
           just-version: 1.35.0
 

--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -92,6 +92,12 @@ jobs:
           pushd optimism > /dev/null
           just install-foundry
 
+      - name: "Generate Kontrol Summaries"
+        run: |
+          pushd optimism/packages/contracts-bedrock > /dev/null
+          just kontrol-summary
+          just kontrol-summary-fp
+
       - name: "Download KCFG Cache Results"
         shell: bash
         run: |

--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -83,10 +83,12 @@ jobs:
           just-version: 1.35.0
 
       - name: "Install Foundry"
+        shell: bash
         run: |
           curl -L https://foundry.paradigm.xyz | bash
 
       - name: "Update Foundry"
+        shell: bash
         run: |
           pushd optimism > /dev/null
           source $HOME/.foundry/bin/foundryup
@@ -94,6 +96,7 @@ jobs:
           just update-foundry
 
       - name: "Generate Kontrol Summaries"
+        shell: bash
         run: |
           pushd optimism/packages/contracts-bedrock > /dev/null
           source $HOME/.foundry/bin/foundryup

--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - uses: "extractions/setup-just@v1"
         with:
-          just-version: 1.23.0
+          just-version: 1.35.0
 
       - name: "Install Foundry"
         run: |

--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -77,24 +77,26 @@ jobs:
       - name: "Set up Rust Toolchain"
         uses: dtolnay/rust-toolchain@stable
 
-      - name: "Cache Rust dependencies"
-        uses: Swatinem/rust-cache@v2
-
-      - name: "Set up Foundry Toolchain"
-        uses: foundry-rs/foundry-toolchain@v1
-
       - uses: "extractions/setup-just@v1"
         with:
           just-version: 1.35.0
 
       - name: "Install Foundry"
         run: |
+          curl -L https://foundry.paradigm.xyz | bash
+
+      - name: "Update Foundry"
+        run: |
           pushd optimism > /dev/null
-          just install-foundry
+          source $HOME/.foundry/bin/foundryup
+          export PATH=$HOME/.foundry/bin:$PATH
+          just update-foundry
 
       - name: "Generate Kontrol Summaries"
         run: |
           pushd optimism/packages/contracts-bedrock > /dev/null
+          source $HOME/.foundry/bin/foundryup
+          export PATH=$HOME/.foundry/bin:$PATH
           just kontrol-summary
           just kontrol-summary-fp
 

--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -74,6 +74,24 @@ jobs:
             git checkout ${{ github.event.inputs.branch_name }}
           fi
 
+      - name: "Set up Rust Toolchain"
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: "Cache Rust dependencies"
+        uses: Swatinem/rust-cache@v2
+
+      - name: "Set up Foundry Toolchain"
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - uses: "extractions/setup-just@v1"
+        with:
+          just-version: 1.23.0
+
+      - name: "Install Foundry"
+        run: |
+          pushd optimism > /dev/null
+          just install-foundry
+
       - name: "Download KCFG Cache Results"
         shell: bash
         run: |


### PR DESCRIPTION
Updates `optimism-ci.yaml` to install `rust`, `foundry`, and `just` so that we can build snapshots as part of `run-kontrol.sh`.