### PR TITLE
Modifying concurrency to NOT cancel in progress builds. For loggin

### DIFF
--- a/.github/workflows/optimism-ci.yaml
+++ b/.github/workflows/optimism-ci.yaml
@@ -24,7 +24,7 @@ on:
 
 # Multiple Runs will need to be allowed to queue
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.branch_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.statuses_sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Changing group tag to contain the commit status the job is running for.

	modified:   .github/workflows/optimism-ci.yaml